### PR TITLE
Upgrade to lit 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.3",
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@web/dev-server": "^0.1",
     "@web/test-runner": "^0.13",
     "@web/test-runner-saucelabs": "^0.7",
@@ -40,7 +40,8 @@
   },
   "dependencies": {
     "@brightspace-ui/core": "^1",
-    "lit-element": "^2"
+    "lit-element": "^3",
+    "lit-html": "^2"
   },
   "version": "2.0.4"
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
+    "@brightspace-ui/core": "^2",
     "@brightspace-ui/logging": "^1.4.0",
     "lit-element": "^3",
     "lit-html": "^2"

--- a/test/lti-launch.test.js
+++ b/test/lti-launch.test.js
@@ -60,7 +60,7 @@ describe('d2l-lti-launch', () => {
 
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('id')).equals(iframeId);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('data-test-id')).equals(iframeTestId);
-			expect(element.shadowRoot.querySelector('iframe').getAttribute('class')).equals(iframeClass);
+			expect(element.shadowRoot.querySelector('iframe').getAttribute('class').trim()).equals(iframeClass);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('src')).equals(`${queryLaunchUrl}&signalStorage=true`);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('title')).equals(`${queryIFrameTitle}&signalStorage=true`);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('height')).equals(iframeHeight);

--- a/test/lti-launch.test.js
+++ b/test/lti-launch.test.js
@@ -34,7 +34,7 @@ describe('d2l-lti-launch', () => {
 
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('id')).equals(iframeId);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('data-test-id')).equals(iframeTestId);
-			expect(element.shadowRoot.querySelector('iframe').getAttribute('class')).equals(iframeClass);
+			expect(element.shadowRoot.querySelector('iframe').getAttribute('class').trim()).equals(iframeClass);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('src')).equals(launchUrl);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('title')).equals(iframeTitle);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('height')).equals(iframeHeight);
@@ -46,7 +46,7 @@ describe('d2l-lti-launch', () => {
 
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('id')).equals(iframeId);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('data-test-id')).equals(iframeTestId);
-			expect(element.shadowRoot.querySelector('iframe').getAttribute('class')).equals(iframeClassNoWidth);
+			expect(element.shadowRoot.querySelector('iframe').getAttribute('class').trim()).equals(iframeClassNoWidth);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('src')).equals(launchUrl);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('title')).equals(iframeTitle);
 			expect(element.shadowRoot.querySelector('iframe').getAttribute('height')).equals(iframeHeight);


### PR DESCRIPTION
https://rally1.rallydev.com/#/?detail=/userstory/622759754161&fdp=true

This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort.

Breaking change checklist: 
- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used)
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement 
- [x] Remove Dependabot Lit rules
- [x] Bump any dependencies to their Lit 2 versions
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers
- [x] Backwards-compatible changes merged: #29

Renamed API's:
- [x] `UpdatingElement` -> `ReactiveElement`
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators)
- [x] `static getStyles()` -> `static finalizeStyles(styles)`
- [x] `_getUpdateComplete()` -> `getUpdateComplete()`
- [x] `NodePart` -> `ChildPart`

Testing checklist: 
- [x] CI/ unit tests pass
- [x] Local testing on demo pages
- [x] Testing component in the LMS

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.