### PR TITLE
DE46450 - Add inside-page param to support iframeless launch

### DIFF
--- a/lti-launch.js
+++ b/lti-launch.js
@@ -45,7 +45,7 @@ class LtiLaunch extends LitElement {
 
 	connectedCallback() {
 		super.connectedCallback();
-		
+
 		if (window === window.top && this.root) {
 			window.location.href = this._launchUrl;
 		}

--- a/lti-launch.js
+++ b/lti-launch.js
@@ -18,9 +18,9 @@ class LtiLaunch extends LitElement {
 				type: String,
 				attribute: 'lti-launch-url'
 			},
-			root: {
+			insidePage: {
 				type: Boolean,
-				attribute: 'root'
+				attribute: 'inside-page'
 			}
 		};
 	}
@@ -40,13 +40,13 @@ class LtiLaunch extends LitElement {
 		super();
 
 		this.iFrameHeight = 600;
-		this.root = false;
+		this.insidePage = false;
 	}
 
 	connectedCallback() {
 		super.connectedCallback();
 
-		if (window === window.top && this.root) {
+		if (window === window.top && this.insidePage) {
 			window.location.href = this._launchUrl;
 		}
 

--- a/lti-launch.js
+++ b/lti-launch.js
@@ -17,6 +17,10 @@ class LtiLaunch extends LitElement {
 			_launchUrl: {
 				type: String,
 				attribute: 'lti-launch-url'
+			},
+			root: {
+				type: Boolean,
+				attribute: 'root'
 			}
 		};
 	}
@@ -36,10 +40,15 @@ class LtiLaunch extends LitElement {
 		super();
 
 		this.iFrameHeight = 600;
+		this.root = false;
 	}
 
 	connectedCallback() {
 		super.connectedCallback();
+		
+		if (window === window.top && this.root) {
+			window.location.href = this._launchUrl;
+		}
 
 		this._handleMessage = this._handleMessage.bind(this);
 		window.addEventListener('message', this._handleMessage);


### PR DESCRIPTION
https://rally1.rallydev.com/#/?detail=/defect/619804525711&fdp=true

Here's the branch in the LMS that makes use of this new param: https://github.com/Brightspace/lms/compare/jcousins/DE46450-launch-no-iframe

Idea is to have a new param called `inside-page` that is set to indicate that this element is fully contained within its own page. Then the component checks if it is the top-most window (not nested in any iframes) and if this inside-page param is set to decide whether to navigate directly to the tool launch URL.