### PR TITLE
Revert "Update release workflow to publish to CodeArtifact"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,28 +16,14 @@ jobs:
         uses: Brightspace/third-party-actions@actions/checkout
         with:
           persist-credentials: false
-
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
         with:
           node-version: '14'
-
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@master
-        id: semantic-release
         with:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
-          NPM: false
-
-      - name: Get CodeArtifact Authorization Token
-        uses: Brightspace/codeartifact-actions/get-authorization-token@v1.5.1
-        if: steps.semantic-release.outputs.VERSION != ''
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
-
-      - name: Publish package
-        if: steps.semantic-release.outputs.VERSION != ''
-        run: npm publish
+          NPM: true
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LTI Components
 
+[![NPM version](https://img.shields.io/npm/v/@brightspace-ui/lti-iframe.svg)](https://www.npmjs.org/package/@brightspace-ui/lti-iframe)
+
 Contains the LTI launch BSI component
 
 ## Installation
@@ -7,7 +9,7 @@ Contains the LTI launch BSI component
 Install from NPM:
 
 ```shell
-npm install @d2l/d2l-lti-components
+npm install @brightspace-ui/lti-iframe
 ```
 
 ## Usage
@@ -129,7 +131,7 @@ npm start
 
 > TL;DR: Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `main`. Read on for more details...
 
-The [semantic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/master/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
+The [sematic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/master/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
 
 ### Version Changes
 
@@ -152,7 +154,7 @@ When a release is triggered, it will:
 * Update the version in `package.json`
 * Tag the commit
 * Create a GitHub release (including release notes)
-* Deploy a new package to CodeArtifact
+* Deploy a new package to NPM
 
 ### Releasing from Maintenance Branches
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@d2l/d2l-lti-components",
+  "name": "d2l-lti-components",
   "description": "A generic LTI launch component",
   "repository": "https://github.com/Brightspace/lti-components.git",
   "scripts": {
@@ -39,7 +39,7 @@
     "/lang"
   ],
   "publishConfig": {
-    "registry": "https://d2l-569998014834.d.codeartifact.us-east-1.amazonaws.com/npm/private/"
+    "access": "public"
   },
   "dependencies": {
     "@brightspace-ui/core": "^1",


### PR DESCRIPTION
Reverts Brightspace/lti-components#50

In order to publish to CodeArtifact this repo needs to be private, which would involve making foundation-components private, and in turn its dependents private, so now is not the time for this work.